### PR TITLE
Updated/added funcationality for latest firmware

### DIFF
--- a/modes/request_preset_names.py
+++ b/modes/request_preset_names.py
@@ -1,6 +1,7 @@
 from modes.standard import Standard
 from out_packet import OutPacket
 import logging
+import threading
 log = logging.getLogger(__name__)
 
 
@@ -8,67 +9,142 @@ class RequestPresetNames(Standard):
 	def __init__(self, helix_usb):
 		Standard.__init__(self, helix_usb=helix_usb, name="request_preset_names")
 		self.preset_names_data = []
+		self.preset_names_stream = []
+		self.stream_parse_idx = 0
+		self.decoded_preset_names = []
+		self.expected_preset_name_count = 126
+		self.idle_watchdog_timer = None
+		self.transfer_complete = False
 
 	def start(self):
 		log.info('Starting mode')
 		self.preset_names_data = []
+		self.preset_names_stream = []
+		self.stream_parse_idx = 0
+		self.decoded_preset_names = []
+		self.transfer_complete = False
+		self._cancel_idle_watchdog()
 		data = [0x1d, 0x0, 0x0, 0x18, 0x1, 0x10, 0xef, 0x3, 0x0, "XX", 0x0, 0xc, 0x38, 0x10, 0x0, 0x0, 0x1, 0x0, 0x2,
 				0x0, 0xd, 0x0, 0x0, 0x0, 0x83, 0x66, 0xcd, 0x3, 0xea, 0x64, 0x1, 0x65, 0x82, 0x6b, 0x0, 0x65, 0x2, 0x0,
 				0x0, 0x0]
 		# data = [0x19, 0x0, 0x0, 0x18, 0x1, 0x10, 0xef, 0x3, 0x0, "XX", 0x0, 0x4, 0x1a, 0x10, 0x0, 0x0, 0x1, 0x0, 0x2, 0x0, 0x9, 0x0, 0x0, 0x0, 0x83, 0x66, 0xcd, 0x3, 0xe9, 0x64, 0x0, 0x65, 0xc0, 0x0, 0x0, 0x0]
 		# data = [0x1a, 0x0, 0x0, 0x18, 0x1, 0x10, 0xef, 0x3, 0x0, "XX", 0x0, 0x4, 0x9, 0x10, 0x0, 0x0, 0x1, 0x0, 0x2, 0x0, 0xa, 0x0, 0x0, 0x0, 0x83, 0x66, 0xcd, 0x3, 0xe8, 0x64, 0xcc, 0xfe, 0x65, 0x80, 0x0, 0x0]
 		self.helix_usb.endpoint_0x1_out(data, silent=True)
+		self._arm_idle_watchdog()
 
 	def shutdown(self):
 		log.info('Shutting down mode')
+		self._cancel_idle_watchdog()
 
-	def parse_preset_names(self):
-		# all_presets = ''
-		all_data = list()
-		for packet in self.preset_names_data:
-			# hex_str = ''.join('0x{:x}, '.format(x) for x in packet)
-			# all_presets += hex_str
-			# ToDo: Move this into the append data function underneath
-			for b in packet[16:]:
-				all_data.append(b)
+	def _cancel_idle_watchdog(self):
+		if self.idle_watchdog_timer is not None:
+			self.idle_watchdog_timer.cancel()
+			self.idle_watchdog_timer = None
 
+	def _arm_idle_watchdog(self):
+		self._cancel_idle_watchdog()
+		self.idle_watchdog_timer = threading.Timer(0.35, self._on_idle_watchdog_timeout)
+		self.idle_watchdog_timer.start()
+
+	def _on_idle_watchdog_timeout(self):
+		if self.transfer_complete:
+			return
+		count = self.parse_preset_names(finalize=True)
+		log.info('Preset-name request idle timeout reached with %d decoded names; finishing request mode', count)
+		self._finish_transfer()
+
+	def _finish_transfer(self):
+		if self.transfer_complete:
+			return
+		self.transfer_complete = True
+		self._cancel_idle_watchdog()
+		self.parse_preset_names(finalize=True)
+
+		self.helix_usb.preset_names = list(self.decoded_preset_names)
+		for idx, name in enumerate(self.decoded_preset_names):
+			log.info('%d: %s', idx, name)
+		log.info('Received preset names: %d', len(self.decoded_preset_names))
+
+		self.helix_usb.got_preset_names = True
+		self.helix_usb.switch_mode()
+
+	def parse_preset_names(self, finalize=False):
 		pattern = [0x81, 0xcd, 0x0]
-		indexes = [(i, i + len(pattern)) for i in range(len(all_data)) if all_data[i:i + len(pattern)] == pattern]
+		record_len = 25  # marker(3) + metadata/name fields up to 16-byte name area
 
-		for index in indexes:
-			name_start_idx = index[1]
-			program_number = all_data[name_start_idx]
-			name = ''
-			for j in range(name_start_idx + 6, name_start_idx + 16 + 6):
-				if all_data[j] == 0x0:
+		while True:
+			search_limit = len(self.preset_names_stream) - len(pattern) + 1
+			if self.stream_parse_idx >= search_limit:
+				if not finalize:
+					self.stream_parse_idx = max(0, len(self.preset_names_stream) - len(pattern) + 1)
+				break
+
+			marker_idx = -1
+			for i in range(self.stream_parse_idx, search_limit):
+				if self.preset_names_stream[i:i + len(pattern)] == pattern:
+					marker_idx = i
 					break
-				name += chr(all_data[j])
-			# log.info(str(program_number) + ' - ' + name)
-		log.info('Received preset names: ' + str(len(indexes)))
+
+			if marker_idx < 0:
+				if not finalize:
+					self.stream_parse_idx = max(0, len(self.preset_names_stream) - len(pattern) + 1)
+				break
+
+			if marker_idx + record_len > len(self.preset_names_stream):
+				if not finalize:
+					self.stream_parse_idx = marker_idx
+				break
+
+			name_bytes = self.preset_names_stream[marker_idx + 9:marker_idx + 25]
+			name_chars = []
+			for b in name_bytes:
+				if b == 0x0:
+					break
+				if 32 <= b <= 126:
+					name_chars.append(chr(b))
+				else:
+					name_chars.append('?')
+			self.decoded_preset_names.append(''.join(name_chars))
+			self.stream_parse_idx = marker_idx + record_len
+
+		return len(self.decoded_preset_names)
+
+	def _append_name_packet_payload(self, packet):
+		self.preset_names_data.append(packet)
+		self.preset_names_stream.extend(packet[16:])
 
 	def data_in(self, data_in):
+		if self.transfer_complete:
+			return False
+
 		if self.helix_usb.check_keep_alive_response(data_in):
 			return False  # don't print incoming message to console
 
 		elif self.helix_usb.my_byte_cmp(left=data_in, right=[0x8, 0x1, 0x0, 0x18, 0xef, 0x3, 0x1, 0x10, 0x0, "XX", 0x0, 0x4, "XX", 0x2, 0x0, 0x0, "XX"], length=17):
 			# one packet
-			self.preset_names_data.append(data_in)
+			self._append_name_packet_payload(data_in)
 			out = OutPacket(data=[0x8, 0x0, 0x0, 0x18, 0x1, 0x10, 0xef, 0x3, 0x0, "XX", 0x0, 0x8, 0x38, data_in[9]+9, 0x0, 0x0])
 			self.helix_usb.out_packet_to_endpoint_0x1(out, silent=True)
+			self._arm_idle_watchdog()
+			decoded_count = self.parse_preset_names()
+			if decoded_count >= self.expected_preset_name_count:
+				log.info('Preset-name request reached expected count (%d), finishing request mode', self.expected_preset_name_count)
+				self._finish_transfer()
 
 		elif self.helix_usb.my_byte_cmp(left=data_in, right=["XX", 0x0, 0x0, 0x18, 0xef, 0x3, 0x1, 0x10, 0x0, "XX", 0x0, 0x4, "XX", 0x2, 0x0, 0x0], length=16):
-			# last packet
+			# packet with payload shape that may be final or intermediate depending on transfer timing
 			out = OutPacket(data=[0x8, 0x0, 0x0, 0x18, 0x1, 0x10, 0xef, 0x3, 0x0, "XX", 0x0, 0x8, 0x38, data_in[9] + 9, 0x0, 0x0])
 			self.helix_usb.out_packet_to_endpoint_0x1(out, silent=True)
 
-			self.preset_names_data.append(data_in)
-			self.parse_preset_names()
-			# print(self.preset_names_data)
-			self.helix_usb.got_preset_names = True
-			self.helix_usb.switch_mode()
+			self._append_name_packet_payload(data_in)
+			self._arm_idle_watchdog()
+			decoded_count = self.parse_preset_names()
+			if decoded_count >= self.expected_preset_name_count:
+				log.info('Preset-name request reached expected count (%d), finishing request mode', self.expected_preset_name_count)
+				self._finish_transfer()
 
 		else:
 			hex_str = ''.join('0x{:x}, '.format(x) for x in data_in)
-			log.warning("Unexpected message in connect mode: " + str(hex_str))
+			log.warning("Unexpected message in mode: " + str(hex_str))
 
 		return True  # print incoming message to console

--- a/modes/standard.py
+++ b/modes/standard.py
@@ -126,6 +126,11 @@ class Standard:
 			# Occurs once while every preset switch initiated at the stomp. data[42] seems to carry the preset number
 			pass
 
+		elif self.helix_usb.my_byte_cmp(left=data, right=[0x27, 0x0, 0x0, 0x18, 0xf0, 0x3, 0x2, 0x10, 0x0, "XX", 0x0, 0x4, 0x9, 0x2, 0x0, 0x0], length=16):
+			# Preset-step and related UI traffic can emit additional 0x27 status frames
+			# that are expected but currently not decoded here. Avoid warning flood.
+			return False
+
 		elif self.helix_usb.my_byte_cmp(left=data, right=[0x8, 0x0, 0x0, 0x18, 0xed, 0x3, 0x80, 0x10, 0x0, "XX", 0x0, 0x8, "XX", "XX", 0x0, 0x0]):
 			# This message signals that a preset transfer has ended in data[11] == 0x08.
 			# Indeed, it should usually be received and properly processed by request_preset mode!


### PR DESCRIPTION
## PR Summary

This PR improves terminal usability and command reliability in [`helix_usb.py`](helix_usb.py), and fixes preset-name retrieval behavior in [`modes/request_preset_names.py`](modes/request_preset_names.py).

### 1) Clean terminal exit
- Added explicit quit commands in the main input loop (`q`, `quit`, `exit`) in [`main()`](helix_usb.py:1).
- Unified interrupt handling (`Ctrl+C`/EOF) into one shutdown path.
- Added idempotent shutdown logic in [`shutdown()`](helix_usb.py:942) to ensure orderly cleanup:
  - stop flags/threads,
  - mode shutdown,
  - logger save,
  - USB resource disposal.
- Updated signal flow so interrupts route through graceful shutdown rather than requiring manual kill.

### 2) Expanded `-h`/usage help
- Extended [`print_usage()`](helix_usb.py:1002) with richer guidance:
  - setup/prerequisites,
  - command usage,
  - examples,
  - interactive command descriptions.
- Help now documents practical runtime actions and current command behavior clearly.

### 3) Preset navigation via MIDI Program Change
- Implemented MIDI Program Change send path in [`send_midi_program_change()`](helix_usb.py:879).
- Added command support:
  - `pu` (preset +1),
  - `pd` (preset -1),
  - `p <n>` (direct preset select, `0..125`) in [`main()`](helix_usb.py:1).
- Added bounds handling and current-preset fallback logic for stepping.
- Implemented Linux USB MIDI interface lifecycle handling to address busy-interface failures:
  - detect/detach kernel driver,
  - claim/release interface,
  - reattach on shutdown when detached by this process.
- Improved actionable error messages when MIDI interface is unavailable or busy.

### 4) Preset-name list retrieval (`2` command)
- Fixed `request_preset_names` flow to avoid premature mode exit and packet spillover.
- Reworked parsing in [`RequestPresetNames.parse_preset_names()`](modes/request_preset_names.py:71) to incremental stream decoding resilient to fragmented packet boundaries.
- Added robust completion behavior:
  - collect until full/expected data,
  - idle-timeout fallback that finalizes buffered complete records before exit.
- Command `2` now outputs the actual preset list (one line per entry):
  - `<index>: <name>`.
- Preset names are stored in memory for reuse (`self.preset_names`) for future UI integration.

### Key files touched
- [`helix_usb.py`](helix_usb.py)
- [`modes/request_preset_names.py`](modes/request_preset_names.py)
- [`modes/standard.py`](modes/standard.py) (handling alignment for expected traffic/noise control during related debugging/fixes)

### Validation
- Repeated syntax verification via [`python3 -m py_compile`](helix_usb.py) on modified modules passed during implementation cycles.